### PR TITLE
feat(homepage): editorial redesign — sage palette, typography hero, plant category grid

### DIFF
--- a/src/app/components/landingHero/LandingHero.stories.tsx
+++ b/src/app/components/landingHero/LandingHero.stories.tsx
@@ -14,11 +14,11 @@ const Template: Story<Props> = args => {
 
 export const Primary = Template.bind({});
 Primary.args = {
-  title: 'Header over multiple lines',
+  title: 'Beautiful plants for every home',
   summary:
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem lacus, elit a diam eget enim venenatis cum. Nibh quis facilisis et hendrerit eu nisl.',
-  ctaLink: '#',
-  ctaText: 'Show now',
-  imageUri: 'https://source.unsplash.com/00fCk2lZn1c',
-  imageAlt: 'Unsplash image',
+    'Discover our hand-picked collection of houseplants, from easy-care favourites to rare botanical treasures. Free UK delivery on orders over £40.',
+  ctaLink: '/shop',
+  ctaText: 'Shop plants',
+  imageUri: 'https://images.unsplash.com/photo-1545239351-ef35f43d514b?w=900',
+  imageAlt: 'Lush green houseplants in a bright living room',
 };

--- a/src/app/components/landingHero/LandingHero.styled.tsx
+++ b/src/app/components/landingHero/LandingHero.styled.tsx
@@ -1,67 +1,58 @@
 import styled, { css } from 'styled-components';
 
 const LandingHeroStyled = styled.div`
-  ${({ theme, src }: { src: string }) => {
+  ${({ theme }) => {
     return css`
-      margin-top: -84px;
-      position: relative;
-      background-image: url(${src});
-      background-size: cover;
-      background-position: top;
-      background-repeat: no-repeat;
-      display: flex;
-      align-items: flex-end;
-      justify-content: center;
-      padding: 0 16px;
-      min-height: 800px;
-      &:before {
-        content: '';
-        background: linear-gradient(
-          180deg,
-          rgba(43, 47, 81, 0.4) 15.88%,
-          rgba(43, 47, 81, 0) 100%
-        );
-        position: absolute;
-        inset: 0;
-        height: 100%;
-        width: 100%;
-      }
+      background-color: var(--semantic-background-primary);
+      padding: 80px 16px;
       @media ${theme.mq.desktop} {
-        display: block;
-        padding: 168px 0;
-        background-size: cover;
-        background-position: center;
+        padding: 120px 0;
       }
-      .landing-hero__content {
-        position: relative;
-        z-index: 2;
-        text-align: center;
-        max-width: 800px;
-        width: 100%;
-        padding: 40px 16px;
-        background: var(--semantic-background-primary);
-        border-radius: 8px 8px 0 0;
-        box-shadow: 0px -16px 24px rgba(56, 33, 146, 0.07);
+      .landing-hero__inner {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 0 24px;
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 48px;
+        align-items: center;
         @media ${theme.mq.desktop} {
-          max-width: 590px;
-          box-shadow: 0px 16px 24px rgba(56, 33, 146, 0.07);
-          padding: 56px 40px 56px 80px;
-          border-radius: 0 8px 8px 0;
-          text-align: left;
+          grid-template-columns: 55fr 45fr;
+          gap: 80px;
+          padding: 0 40px;
         }
       }
+      .landing-hero__content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+      }
+      .landing-hero__rule {
+        display: block;
+        width: 60px;
+        height: 2px;
+        background-color: var(--semantic-brand-primary);
+        margin-bottom: 32px;
+      }
       .landing-hero__title {
-        margin: 0 0 16px;
+        margin: 0 0 24px;
       }
       .landing-hero__summary {
-        margin: 0 auto 40px;
-        max-width: 590px;
-        width: 100%;
+        margin: 0 0 40px;
+        max-width: 520px;
+        color: var(--semantic-charcoal-primary);
       }
       .landing-hero__btn {
-        margin: 0 auto;
+        margin: 0;
+      }
+      .landing-hero__photo {
+        display: none;
         @media ${theme.mq.desktop} {
-          margin: 0;
+          display: block;
+          width: 100%;
+          aspect-ratio: 4 / 5;
+          object-fit: cover;
+          border-radius: 8px;
         }
       }
     `;

--- a/src/app/components/landingHero/LandingHero.tsx
+++ b/src/app/components/landingHero/LandingHero.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Region from '../../layout/Region';
 import GenericHero from '../genericHero/GenericHero';
 import LinkButton from '../linkButton/LinkButton';
 import LandingHeroStyled from './LandingHero.styled';
@@ -15,12 +14,12 @@ export interface Props {
   hasIllustration?: boolean;
   heroIllustrationUri?: string;
   heroIllustrationAlt?: string;
-  headingLevel?: number;
 }
 
 const LandingHero = ({
   className,
   imageUri,
+  imageAlt,
   title,
   summary,
   ctaLink,
@@ -29,36 +28,43 @@ const LandingHero = ({
   heroIllustrationUri,
   heroIllustrationAlt,
 }: Props) => {
-  const _RenderHero = (hasIllustration: boolean) => {
-    if (hasIllustration) {
-      return (
-        <GenericHero
-          title={title}
-          image={{ src: heroIllustrationUri || '', alt: heroIllustrationAlt }}
-          cta={{ a11y: ctaLink || '', label: ctaText }}
-          text={summary}
-        />
-      );
-    } else {
-      return (
-        <LandingHeroStyled className={className} src={imageUri}>
-          <div className="landing-hero__content">
-            <h1 className="landing-hero__title">{title}</h1>
-            {summary && <p className="landing-hero__summary">{summary}</p>}
-            {ctaLink && (
-              <LinkButton
-                className="landing-hero__btn"
-                icon="arrow-right"
-                label={ctaText}
-                path={ctaLink}
-              />
-            )}
-          </div>
-        </LandingHeroStyled>
-      );
-    }
-  };
-  return <>{_RenderHero(hasIllustration)}</>;
+  if (hasIllustration) {
+    return (
+      <GenericHero
+        title={title}
+        image={{ src: heroIllustrationUri || '', alt: heroIllustrationAlt }}
+        cta={{ a11y: ctaLink || '', label: ctaText }}
+        text={summary}
+      />
+    );
+  }
+
+  return (
+    <LandingHeroStyled className={className} data-component="landing-hero">
+      <div className="landing-hero__inner">
+        <div className="landing-hero__content">
+          <span className="landing-hero__rule" aria-hidden="true" />
+          <h1 className="landing-hero__title">{title}</h1>
+          {summary && <p className="landing-hero__summary">{summary}</p>}
+          {ctaLink && (
+            <LinkButton
+              className="landing-hero__btn"
+              icon="arrow-right"
+              label={ctaText}
+              path={ctaLink}
+            />
+          )}
+        </div>
+        {imageUri && (
+          <img
+            className="landing-hero__photo"
+            src={imageUri}
+            alt={imageAlt || ''}
+          />
+        )}
+      </div>
+    </LandingHeroStyled>
+  );
 };
 
 export default LandingHero;

--- a/src/app/components/linkButton/LinkButton.styled.tsx
+++ b/src/app/components/linkButton/LinkButton.styled.tsx
@@ -4,8 +4,8 @@ import Link from '../link/Link';
 export default styled(Link)`
   ${({ theme }) => {
     return css`
-      --semantic-riptide-primary: #77e8c6;
-      --semantic-riptide-secondary: #39b28e;
+      --semantic-riptide-primary: #8FBC8F;
+      --semantic-riptide-secondary: #6B9E74;
       --semantic-martinique-primary: #2b2f51;
       --semantic-martinique-secondary: #1e213e;
       --semantic-martinique-tertiary: rgba(195, 198, 222, 0.2);

--- a/src/app/components/plantCategoryGrid/PlantCategoryGrid.d.ts
+++ b/src/app/components/plantCategoryGrid/PlantCategoryGrid.d.ts
@@ -1,0 +1,11 @@
+export interface PlantCategory {
+  title: string;
+  description?: string;
+  image: { src: string; alt: string };
+  path: string;
+}
+
+export interface Props {
+  title?: string;
+  categories: PlantCategory[];
+}

--- a/src/app/components/plantCategoryGrid/PlantCategoryGrid.stories.tsx
+++ b/src/app/components/plantCategoryGrid/PlantCategoryGrid.stories.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import PlantCategoryGrid from './PlantCategoryGrid';
+import { Props } from './PlantCategoryGrid.d';
+
+export default {
+  title: 'Landing/Components/PlantCategoryGrid',
+  component: PlantCategoryGrid,
+} as Meta;
+
+const Template: Story<Props> = args => <PlantCategoryGrid {...args} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  title: 'Find your perfect plant',
+  categories: [
+    {
+      title: 'Low Light',
+      description: 'Thrives in shady spots and north-facing rooms',
+      image: {
+        src: 'https://images.unsplash.com/photo-1604762524889-3e2fcc145683?w=600',
+        alt: 'A snake plant in a dark corner',
+      },
+      path: '/collections/low-light',
+    },
+    {
+      title: 'Easy Care',
+      description: 'Perfect for beginners and busy plant parents',
+      image: {
+        src: 'https://images.unsplash.com/photo-1463936575829-25148e1db1b8?w=600',
+        alt: 'A pothos plant on a shelf',
+      },
+      path: '/collections/easy-care',
+    },
+    {
+      title: 'Pet-Friendly',
+      description: 'Safe for cats, dogs and curious noses',
+      image: {
+        src: 'https://images.unsplash.com/photo-1598880940942-e6854d7b3bef?w=600',
+        alt: 'A spider plant in a hanging planter',
+      },
+      path: '/collections/pet-friendly',
+    },
+  ],
+};

--- a/src/app/components/plantCategoryGrid/PlantCategoryGrid.styled.ts
+++ b/src/app/components/plantCategoryGrid/PlantCategoryGrid.styled.ts
@@ -1,0 +1,80 @@
+import styled, { css } from 'styled-components';
+
+export default styled.section`
+  ${({ theme }) => {
+    return css`
+      background-color: var(--semantic-background-primary);
+      padding: 80px 16px;
+      @media ${theme.mq.desktop} {
+        padding: 120px 40px;
+      }
+      .plant-category-grid__inner {
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+      .plant-category-grid__title {
+        text-align: center;
+        margin-bottom: 56px;
+        @media ${theme.mq.desktop} {
+          margin-bottom: 64px;
+        }
+      }
+      .plant-category-grid__grid {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 24px;
+        @media ${theme.mq.tablet} {
+          grid-template-columns: repeat(2, 1fr);
+        }
+        @media ${theme.mq.desktop} {
+          grid-template-columns: repeat(3, 1fr);
+          gap: 32px;
+        }
+      }
+      .plant-category-grid__card {
+        position: relative;
+        border-radius: 8px;
+        overflow: hidden;
+        transition: transform 200ms ease-out;
+        &:hover {
+          transform: translateY(-4px);
+        }
+        &:focus-within {
+          outline: 2px solid var(--semantic-link-primary);
+          outline-offset: 2px;
+        }
+      }
+      .plant-category-grid__image {
+        width: 100%;
+        aspect-ratio: 3 / 4;
+        object-fit: cover;
+        display: block;
+      }
+      .plant-category-grid__card-body {
+        padding: 20px 0 8px;
+      }
+      .plant-category-grid__card-title {
+        ${theme.typeStyles.h4};
+        color: var(--semantic-type-primary);
+        margin: 0 0 8px;
+      }
+      .plant-category-grid__card-description {
+        ${theme.typeStyles.smallCopy};
+        color: var(--semantic-charcoal-primary);
+        margin: 0;
+      }
+      .plant-category-grid__card-link {
+        color: inherit;
+        text-decoration: none;
+        &:after {
+          content: '';
+          position: absolute;
+          inset: 0;
+        }
+        &:focus {
+          outline: none;
+        }
+      }
+    `;
+  }};
+`;

--- a/src/app/components/plantCategoryGrid/PlantCategoryGrid.tsx
+++ b/src/app/components/plantCategoryGrid/PlantCategoryGrid.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Link from '../link/Link';
+import PlantCategoryGridStyled from './PlantCategoryGrid.styled';
+import { Props } from './PlantCategoryGrid.d';
+
+const PlantCategoryGrid = ({ title, categories }: Props) => {
+  if (!categories || categories.length < 1) return null;
+
+  return (
+    <PlantCategoryGridStyled data-component="plant-category-grid">
+      <div className="plant-category-grid__inner">
+        {title && <h2 className="plant-category-grid__title">{title}</h2>}
+        <ul className="plant-category-grid__grid" role="list">
+          {categories.map((category, index) => (
+            <li key={index} className="plant-category-grid__card">
+              <img
+                className="plant-category-grid__image"
+                src={category.image.src}
+                alt={category.image.alt}
+                loading="lazy"
+              />
+              <div className="plant-category-grid__card-body">
+                <h3 className="plant-category-grid__card-title">
+                  <Link
+                    className="plant-category-grid__card-link"
+                    path={category.path}
+                  >
+                    {category.title}
+                  </Link>
+                </h3>
+                {category.description && (
+                  <p className="plant-category-grid__card-description">
+                    {category.description}
+                  </p>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </PlantCategoryGridStyled>
+  );
+};
+
+export default PlantCategoryGrid;

--- a/src/app/components/testimonialSlider/TestimonialSlider.stories.tsx
+++ b/src/app/components/testimonialSlider/TestimonialSlider.stories.tsx
@@ -27,5 +27,4 @@ for (let i = 0; testimonials.length < 3; i++) {
 export const Primary = Template.bind({});
 Primary.args = {
   testimonials,
-  bgImage: 'https://source.unsplash.com/c4Ccpa8sMlI',
 };

--- a/src/app/components/testimonialSlider/TestimonialSlider.styled.tsx
+++ b/src/app/components/testimonialSlider/TestimonialSlider.styled.tsx
@@ -7,71 +7,55 @@ interface Props {
 const TestimonialSliderStyled = styled.div`
   ${({ theme }: Props) => {
     return css`
-      background-color: var(--semantic-type-primary);
-      background-image: url('/static/img/backgrounds/testimonial-slider-background.jpeg');
-      background-size: cover;
-      background-position: center;
-      position: relative;
-      &:before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: var(--semantic-type-primary);
-        opacity: 0.9;
-      }
+      background-color: var(--semantic-background-warm);
+      padding: 80px 16px;
       @media ${theme.mq.desktop} {
+        padding: 96px 40px;
         display: flex;
         flex-direction: column;
         justify-content: center;
         align-items: center;
-        min-height: 600px;
       }
       .testimonial-slider__wrapper {
         max-width: 620px;
         width: 100%;
         margin: 0 auto;
+        position: relative;
         &:before {
-          content: '';
-          position: absolute;
-          top: -24px;
-          left: 50%;
-          height: 160px;
-          width: 12px;
-          transform: rotate(90deg);
-          background-image: url('/static/img/svgs/shapes/quote-block-shape.svg');
-          background-repeat: no-repeat;
-        }
-        @media ${theme.mq.desktop} {
-          &:before {
-            top: 32px;
-          }
+          content: '\u201C';
+          display: block;
+          font-family: 'Source Serif 4', serif;
+          font-size: 6rem;
+          line-height: 1;
+          color: var(--semantic-brand-primary);
+          margin-bottom: 16px;
         }
       }
       .testimonial__pagination {
-        text-align: center;
-        color: var(--semantic-brand-primary);
-        ${theme.typeStyles.smallCopy};
-        position: absolute;
-        bottom: 132px;
-        left: 50%;
-        transform: translateX(-50%);
-        @media ${theme.mq.desktop} {
-          position: relative;
-          bottom: auto;
-          left: auto;
-          transform: unset;
-        }
+        display: flex;
+        justify-content: center;
+        gap: 8px;
+        margin-top: 32px;
+      }
+      .testimonial__dot {
+        display: block;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background-color: var(--semantic-charcoal-secondary);
+        transition: background-color 200ms ease-out;
+      }
+      .testimonial__dot--active {
+        background-color: var(--semantic-brand-primary);
       }
       .slick-next,
       .slick-prev {
         bottom: 64px;
         top: auto;
-        background-color: var(--semantic-background-primary);
+        background-color: transparent;
+        border: 1px solid var(--semantic-brand-primary);
         svg path {
-          fill: var(--semantic-type-primary);
+          fill: var(--semantic-brand-primary);
         }
         @media ${theme.mq.desktop} {
           bottom: auto;

--- a/src/app/components/testimonialSlider/TestimonialSlider.tsx
+++ b/src/app/components/testimonialSlider/TestimonialSlider.tsx
@@ -9,13 +9,13 @@ export interface Props {
 }
 
 const TestimonialSlider = ({ className, testimonials }: Props) => {
-  const [currentSlide, setCurrentSlide] = useState<number>(1);
+  const [currentSlide, setCurrentSlide] = useState<number>(0);
   const updateCurrentSlide = (currentSlide: number) => {
-    setCurrentSlide(currentSlide + 1);
+    setCurrentSlide(currentSlide);
   };
-  const maxSlides = testimonials.length;
 
   if (!testimonials || testimonials.length < 1) return null;
+
   return (
     <TestimonialSliderStyled className={className}>
       <div className="testimonial-slider__wrapper">
@@ -24,10 +24,15 @@ const TestimonialSlider = ({ className, testimonials }: Props) => {
           slides={testimonials}
           className="testimonial-slider__slider"
           afterChangeFunc={updateCurrentSlide}
-          arrowColor="#2B2F51"
+          arrowColor="var(--semantic-brand-primary)"
         />
-        <div className="testimonial__pagination">
-          {currentSlide} &#47; {maxSlides}
+        <div className="testimonial__pagination" aria-hidden="true">
+          {testimonials.map((_: any, idx: number) => (
+            <span
+              key={idx}
+              className={`testimonial__dot${idx === currentSlide ? ' testimonial__dot--active' : ''}`}
+            />
+          ))}
         </div>
       </div>
     </TestimonialSliderStyled>

--- a/src/app/pages/Home/Home.d.ts
+++ b/src/app/pages/Home/Home.d.ts
@@ -3,12 +3,14 @@ import { Props as ComposerProps } from '~/components/composer/ComposerWrapper';
 import { Props as LandingHeroProps } from '~/components/landingHero/LandingHero';
 import { Props as CTABannerProps } from '~/components/ctaBanner/CTABanner';
 import { Props as MetadataProps } from '~/components/metadata/Metadata';
+import { Props as PlantCategoryGridProps } from '~/components/plantCategoryGrid/PlantCategoryGrid.d';
 
 export interface MappedProps {
   meta: MetadataProps;
   hero: LandingHeroProps;
   composer: ComposerProps;
   banner: CTABannerProps;
+  plantCategories: PlantCategoryGridProps;
 }
 
 export type Props = RouteComponentProps<MappedProps>;

--- a/src/app/pages/Home/Home.page.tsx
+++ b/src/app/pages/Home/Home.page.tsx
@@ -9,11 +9,42 @@ import CTABanner from '~/components/ctaBanner/CTABanner';
 import Metadata from '~/components/metadata/Metadata';
 import MainLayout from '~/layout/MainLayout';
 import CardRow from '~/components/cardRow/CardRow';
+import PlantCategoryGrid from '~/components/plantCategoryGrid/PlantCategoryGrid';
 import { mappers } from '~/components/search';
 
 // Models
 import { Props, MappedProps } from './Home.d';
 import HomepageStyled from './Homepage.styled';
+
+const PLANT_CATEGORIES = [
+  {
+    title: 'Low Light',
+    description: 'Thrives in shady spots and north-facing rooms',
+    image: {
+      src: '/static/img/categories/low-light.jpg',
+      alt: 'A snake plant in a dark corner',
+    },
+    path: '/collections/low-light',
+  },
+  {
+    title: 'Easy Care',
+    description: 'Perfect for beginners and busy plant parents',
+    image: {
+      src: '/static/img/categories/easy-care.jpg',
+      alt: 'A pothos plant on a shelf',
+    },
+    path: '/collections/easy-care',
+  },
+  {
+    title: 'Pet-Friendly',
+    description: 'Safe for cats, dogs and curious noses',
+    image: {
+      src: '/static/img/categories/pet-friendly.jpg',
+      alt: 'A spider plant in a hanging planter',
+    },
+    path: '/collections/pet-friendly',
+  },
+];
 
 const Home = ({ mappedEntry }: Props) => {
   const { meta, hero, composer, banner } = (mappedEntry || {}) as MappedProps;
@@ -22,10 +53,14 @@ const Home = ({ mappedEntry }: Props) => {
   const blogs = useMinilist({ id: 'latestBlogs', mapper: mappers.results });
 
   return (
-    <MainLayout isLight={true}>
+    <MainLayout isLight={false}>
       <HomepageStyled>
         <Metadata {...meta} />
         <LandingHero {...hero} />
+        <PlantCategoryGrid
+          title="Find your perfect plant"
+          categories={PLANT_CATEGORIES}
+        />
         <Composer {...composer} />
         <TestimonialSlider testimonials={reviews.results} />
         <CardRow

--- a/src/app/pages/Home/Homepage.styled.ts
+++ b/src/app/pages/Home/Homepage.styled.ts
@@ -5,9 +5,9 @@ export default styled.div`
     return css`
       [data-component='cta-block'],
       [data-component='card-row'] {
-        margin: 80px auto;
+        margin: 100px auto;
         @media ${theme.mq.laptop} {
-          margin: 120px auto;
+          margin: 140px auto;
         }
       }
     `;

--- a/src/app/theme/global/globalStyles.ts
+++ b/src/app/theme/global/globalStyles.ts
@@ -16,11 +16,12 @@ const GlobalStyle = createGlobalStyle`
   }
 
   :root {
-    --semantic-brand-primary: #77E8C6;
+    --semantic-brand-primary: #8FBC8F;
     --semantic-brand-secondary: #016F4E;
     --semantic-brand-tertiary: #39B38E;
     --semantic-background-primary: #fff;
     --semantic-background-secondary: #000;
+    --semantic-background-warm: #FAFAF8;
     --semantic-type-primary: #2b2f51;
     --semantic-type-secondary: #6e729b;
     --semantic-type-tertiary: #1e213e;
@@ -108,7 +109,7 @@ const GlobalStyle = createGlobalStyle`
   }
 
   tbody tr:nth-child(2n + 1) {
-    background-color: rgba(119, 232, 198, 0.1);
+    background-color: rgba(143, 188, 143, 0.1);
   }
 
   ul, ol {


### PR DESCRIPTION
## Summary

- **Design tokens:** Replace bright mint (`#77E8C6`) with sage green (`#8FBC8F`) across all token references; add new `--semantic-background-warm` (`#FAFAF8`) warm off-white token. Update hardcoded hex values in `LinkButton.styled.tsx` and table zebra stripes.
- **Hero redesign:** `LandingHero` rewritten from full-bleed background image + floating white card → editorial two-column layout. Large Source Serif 4 headline fills the left column as the primary visual anchor; editorial accent photo sits in the right column on desktop. Decorative sage rule above the headline. `imageAlt` prop bug fixed (was declared but never passed to `<img>`).
- **New section:** `PlantCategoryGrid` — "Find your perfect plant" 3-column responsive editorial grid with portrait-ratio cards, full-card link pattern, hover lift, and Storybook story. Hardcoded with 3 starter categories (Low Light, Easy Care, Pet-Friendly); CMS integration is a follow-up.
- **Testimonials:** Remove heavy dark background and background-image overlay. New cream/warm-white background, typographic `"` quotation mark in sage, dot pagination (rendered from React state), sage arrow buttons.
- **Spacing:** Section vertical rhythm increased from `80px/120px` → `100px/140px` for editorial breathing room.
- **Header:** `isLight={false}` — switches to dark logo now that hero background is white.

## Testing

- No tests exist in this project (Storybook only) — all 3 new/modified components have updated Storybook stories
- All TypeScript errors are pre-existing (node_modules type conflicts) — zero new errors introduced in `src/`
- Responsive breakpoints: mobile → tablet → laptop → desktop handled in each styled component

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: all changes are purely presentational (Styled Components + JSX structure). No new data fetching, API calls, or state management changes. Visual QA on staging is the primary validation.

## Follow-up

- Wire `PlantCategoryGrid` categories to a CMS minilist so editors can manage them
- Validate sage `#8FBC8F` contrast ratio on warm white `#FAFAF8` with browser DevTools (WCAG AA: 4.5:1 for text, 3:1 for UI)
- Supply real plant category photography to `/static/img/categories/`

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)